### PR TITLE
Fix links to courses.zurb.com and on templates.html

### DIFF
--- a/src/layouts/apps.html
+++ b/src/layouts/apps.html
@@ -39,7 +39,7 @@
           <li><label class="first">More zurb goodness</label></li>
           <li><a href="https://zurb.com/notable">Notable</a></li>
           <li><a href="https://zurb.com/manifesto">Manifesto</a></li>
-          <li><a href="https://courses.zurb.com/">Foundation Training</a></li>
+          <li><a href="https://zurb.com/university">Foundation Training</a></li>
         </ul>
 
         <hr>

--- a/src/pages/50x.html
+++ b/src/pages/50x.html
@@ -14,7 +14,7 @@ name: The most advanced responsive front-end framework in the world.
         <h3>Or try one of these:</h3>
         <ul>
         	<li><a href="{{root}}learn/features.html" class="">What's new in Foundation 5</a></li>
-        	<li><a href="https://courses.zurb.com/">Foundation Training</a></li>
+        	<li><a href="https://zurb.com/university">Foundation Training</a></li>
         	<li><a href="{{root}}templates.html">HTML Templates for Foundation</a></li>
         	<li><a href="{{root}}support/support.html" class="">Foundation Support</a></li>
         	<li><a href="{{root}}sites/premium-support.html" class="">Premium Support</a></li>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -128,7 +128,7 @@ name: The most advanced responsive front-end framework in the world.
         <a href="https://zurb.com/university/advanced-foundation-training" class="button">Learn More</a>
       </div>
     </a>
-    <a href="https://courses.zurb.com">
+    <a href="https://zurb.com/university">
       <div class="column container-hover vertical-feature-block">
         <img src="https://get.foundation/assets/img/learn/features/customizable-sass-grid.svg" class="" height="" width="" alt="">
         <h3 class="feature-block-header">Foundation Certification</h3>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -120,7 +120,7 @@ name: The most advanced responsive front-end framework in the world.
         <a href="https://zurb.com/university/foundation-intro" class="button">Learn More</a>
       </div>
     </a>
-    <a href="https://courses.zurb.com/p/advanced-foundation-6">
+    <a href="https://zurb.com/university/advanced-foundation-training">
       <div class="column container-hover vertical-feature-block">
         <img src="https://zurb.com/university/assets/courses/stickers/advanced-foundation-training-sticker-e13d1287aaab71c1490b17489cc09050.svg" class="" height="" width="" alt="">
         <h3 class="feature-block-header">Advanced Foundation</h3>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -112,7 +112,7 @@ name: The most advanced responsive front-end framework in the world.
   <h4 class="subheader text-center" style="max-width: 900px; margin: 0 auto 2rem;">ZURB has been practicing product design since 1998 and our online webinar training will teach you and your team the same valuable skills our designers use on a daily basis.</h4>
 
   <div class="row small-up-1 medium-up-3 homepage-training">
-    <a href="https://courses.zurb.com/p/introduction-to-foundation-6">
+    <a href="https://zurb.com/university/foundation-intro">
       <div class="column container-hover vertical-feature-block">
         <img src="{{root}}assets/img/learn/features/svgs/code-reduction-01.svg" class="" height="" width="" alt="">
         <h3 class="feature-block-header">Intro to Foundation</h3>

--- a/src/pages/learn/adding-images-best-practices-foundation-for-emails-dave-horan.html
+++ b/src/pages/learn/adding-images-best-practices-foundation-for-emails-dave-horan.html
@@ -6,7 +6,7 @@ name: Best Practices for Adding Images to a Responsive Email
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/advanced-sass-hmanchanda-1.html
+++ b/src/pages/learn/advanced-sass-hmanchanda-1.html
@@ -11,7 +11,7 @@ secondary-button-text: Learn More About Foundation Training
 
 class-benefit-header: Get all your questions answered in our Advanced Foundation Course.
 
-course-url: https://courses.zurb.com/p/advanced-foundation-6
+course-url: https://zurb.com/university/advanced-foundation-training
 ---
 
 {{> subnav-learn}}

--- a/src/pages/learn/build-your-career-on-a-solid-foundation.html
+++ b/src/pages/learn/build-your-career-on-a-solid-foundation.html
@@ -7,7 +7,7 @@ name: Build Your Career On A Solid Foundation
 
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/building-a-hero-unit-with-foundation-6.html
+++ b/src/pages/learn/building-a-hero-unit-with-foundation-6.html
@@ -6,7 +6,7 @@ name: Building a Hero Unit with Foundation 6
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/building-a-responsive-footer-with-foundation-6-gary-jenning.html
+++ b/src/pages/learn/building-a-responsive-footer-with-foundation-6-gary-jenning.html
@@ -6,7 +6,7 @@ name: Building a Responsive Footer with Foundation 6
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/building-a-responsive-navigation-gary-jennings.html
+++ b/src/pages/learn/building-a-responsive-navigation-gary-jennings.html
@@ -6,7 +6,7 @@ name: Scaffolding a Responsive Navigation with Foundation 6
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/building-the-mobile-off-canvas-menu-gary-jennings.html
+++ b/src/pages/learn/building-the-mobile-off-canvas-menu-gary-jennings.html
@@ -6,7 +6,7 @@ name: Building the Mobile Off-Canvas Menu
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/certification.html
+++ b/src/pages/learn/certification.html
@@ -7,7 +7,7 @@ name: Business Certification
   <ul class="marketing-subnav">
   	<li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
-  	<li><a href="https://courses.zurb.com/">Courses</a></li>
+  	<li><a href="https://zurb.com/university">Courses</a></li>
   	<li><a href="{{root}}learn/custom-training.html" >Custom Training</a></li>
   	<li><a href="{{root}}learn/certification.html" class="is-active">Certification</a></li>
   </ul>

--- a/src/pages/learn/classes.html
+++ b/src/pages/learn/classes.html
@@ -6,7 +6,7 @@ name: Sharpen your Responsive Design Skills with Foundation Training
   <h1 class="hero-main-header">Foundation 6 Classes</h1>
   <ul class="marketing-subnav">
   	<li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-  	<li><a href="https://courses.zurb.com/" class="is-active">Courses</a></li>
+  	<li><a href="https://zurb.com/university" class="is-active">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
   	<li><a href="https://zurb.com/university/training">Custom Training</a></li>
   	<!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/create-a-responsive-layout-with-foundation-6-gary-jenning.html
+++ b/src/pages/learn/create-a-responsive-layout-with-foundation-6-gary-jenning.html
@@ -6,7 +6,7 @@ name: Creating a Responsive Layout with Foundation 6
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/custom-training.html
+++ b/src/pages/learn/custom-training.html
@@ -6,7 +6,7 @@ name: Custom Foundation Training for Businesses
   <h1 class="hero-main-header">Custom Foundation Training</h1>
     <ul class="marketing-subnav">
     	<li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    	<li><a href="https://courses.zurb.com/">Courses</a></li>
+    	<li><a href="https://zurb.com/university">Courses</a></li>
     	<li><a href="{{root}}learn/custom-training.html" class="is-active">Custom Training</a></li>
     	<!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->
       <!-- <li><a href="{{root}}learn/responsive-reading.html">Responsive Reading</a></li> -->

--- a/src/pages/learn/flexbox-helper-classes.html
+++ b/src/pages/learn/flexbox-helper-classes.html
@@ -13,7 +13,7 @@ secondary-button-text: Learn More About Foundation Training
 
 class-benefit-header: Get all your questions answered in our Advanced Foundation Course.
 
-course-url: https://courses.zurb.com/p/introduction-to-foundation-6
+course-url: https://zurb.com/university/foundation-intro
 ---
 
 {{> subnav-learn}}

--- a/src/pages/learn/foundation-grid-patterns.html
+++ b/src/pages/learn/foundation-grid-patterns.html
@@ -6,7 +6,7 @@ name: Real World Foundation Grid Patterns
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/foundation-intro.html
+++ b/src/pages/learn/foundation-intro.html
@@ -50,7 +50,7 @@ name: Intro to Foundation
       <div class="small-12 columns">
         <h3 class="centered-text">On-Demand Course Access Begins Now!</h3>
           <div class="centered-text callout-buttons">
-          <a id="EmailTopRegisterButton" href="https://courses.zurb.com/p/introduction-to-foundation-6" class="button enroll-btn large scroll-to-anchor">Register Now</a>
+          <a id="EmailTopRegisterButton" href="https://zurb.com/university/foundation-intro" class="button enroll-btn large scroll-to-anchor">Register Now</a>
         </div>
       </div>
     </div>
@@ -337,7 +337,7 @@ name: Intro to Foundation
       <div class="small-12 columns">
         <h3 class="centered-text">On-Demand Course Access Begins Now!</h3>
           <div class="centered-text callout-buttons">
-          <a id="EmailTopRegisterButton" href="https://courses.zurb.com/p/introduction-to-foundation-6" class="button enroll-btn large scroll-to-anchor">Register Now</a>
+          <a id="EmailTopRegisterButton" href="https://zurb.com/university/foundation-intro" class="button enroll-btn large scroll-to-anchor">Register Now</a>
         </div>
       </div>
     </div>

--- a/src/pages/learn/foundation-intro.html
+++ b/src/pages/learn/foundation-intro.html
@@ -11,7 +11,7 @@ name: Intro to Foundation
 <p style="color: #fff;">Learn in-demand front-end development skills straight from the Foundation team.</p>
   <ul class="marketing-subnav">
     <li><a href="https://get.foundation/learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/" class="is-active">Courses</a></li>
+    <li><a href="https://zurb.com/university" class="is-active">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="https://get.foundation/learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/get-your-team-on-a-solid-foundation.html
+++ b/src/pages/learn/get-your-team-on-a-solid-foundation.html
@@ -7,7 +7,7 @@ name: Get Your Team on a Solid Foundation
 
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/getting-started-with-foundation-6-gary-jennings.html
+++ b/src/pages/learn/getting-started-with-foundation-6-gary-jennings.html
@@ -6,7 +6,7 @@ name: Getting Started with Foundation 6 CSS
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/install-foundation-6-sass-on-windows.html
+++ b/src/pages/learn/install-foundation-6-sass-on-windows.html
@@ -6,7 +6,7 @@ name: Install Foundation 6 Sass on Windows
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/installing-the-zurb-stack-foundation-for-emails-dave-horan.html
+++ b/src/pages/learn/installing-the-zurb-stack-foundation-for-emails-dave-horan.html
@@ -6,7 +6,7 @@ name: Installing Foundation for Emails and the ZURB Stack
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/intro-to-gulp-task-runner-zurb-stack-foundation.html
+++ b/src/pages/learn/intro-to-gulp-task-runner-zurb-stack-foundation.html
@@ -6,7 +6,7 @@ name: Do More With Less - Intro to the Gulp Task Runner
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/introduction-to-the-foundation-grid.html
+++ b/src/pages/learn/introduction-to-the-foundation-grid.html
@@ -6,7 +6,7 @@ name: Introduction to the Foundation Grid
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/layout-and-spacing-with-foundation-6-gary-jennings.html
+++ b/src/pages/learn/layout-and-spacing-with-foundation-6-gary-jennings.html
@@ -6,7 +6,7 @@ name: Getting Your Layout and Spacing Right
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/leverage-the-power-of-design.html
+++ b/src/pages/learn/leverage-the-power-of-design.html
@@ -7,7 +7,7 @@ name: Leverage The Power of Design For Your Business
 
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/refining-and-styling-the-hero-and-footer-gary-jennings.html
+++ b/src/pages/learn/refining-and-styling-the-hero-and-footer-gary-jennings.html
@@ -6,7 +6,7 @@ name: Refining and Styling the Hero and Footer
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/refining-the-responsive-navigation-gary-jenning.html
+++ b/src/pages/learn/refining-the-responsive-navigation-gary-jenning.html
@@ -6,7 +6,7 @@ name: Refining and Styling the Foundation 6 Responsive Navigation
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/refining-the-responsive-navigation-p2-gary-jenning.html
+++ b/src/pages/learn/refining-the-responsive-navigation-p2-gary-jenning.html
@@ -6,7 +6,7 @@ name: Refining and Styling the Foundation 6 Responsive Navigation
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/responsive-reading.html
+++ b/src/pages/learn/responsive-reading.html
@@ -7,7 +7,7 @@ name: Responsive Reading
 
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/setting-up-foundation-6-css-gary-jennings.html
+++ b/src/pages/learn/setting-up-foundation-6-css-gary-jennings.html
@@ -6,7 +6,7 @@ name: Setting Up Your Foundation 6 CSS Project
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/style-your-site-fast-foundation-sass-settings.html
+++ b/src/pages/learn/style-your-site-fast-foundation-sass-settings.html
@@ -6,7 +6,7 @@ name: Do More With Less - Intro to the Gulp Task Runner
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/styling-the-mobile-off-canvas-menu-gary-jennings.html
+++ b/src/pages/learn/styling-the-mobile-off-canvas-menu-gary-jennings.html
@@ -6,7 +6,7 @@ name: Building the Mobile Off-Canvas Menu
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/tutorials.html
+++ b/src/pages/learn/tutorials.html
@@ -6,7 +6,7 @@ name: Tutorials
   <h1 class="hero-main-header">Get Started with Tutorials</h1>
   <ul class="marketing-subnav">
   	<li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-  	<li><a href="https://courses.zurb.com/">Courses</a></li>
+  	<li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
   	<li><a href="https://zurb.com/university/training">Custom Training</a></li>
   	<!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/upgrade-foundation-6-rails-gem.html
+++ b/src/pages/learn/upgrade-foundation-6-rails-gem.html
@@ -6,7 +6,7 @@ name: Upgrade to the Foundation 6 Rails Gem
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/what-is-flexbox.html
+++ b/src/pages/learn/what-is-flexbox.html
@@ -13,7 +13,7 @@ secondary-button-text: Learn More About Foundation Training
 
 class-benefit-header: Get all your questions answered in our Advanced Foundation Course.
 
-course-url: https://courses.zurb.com/p/introduction-to-foundation-6
+course-url: https://zurb.com/university/foundation-intro
 ---
 
 {{> subnav-learn}}

--- a/src/pages/learn/working-with-foundation-for-emails-layouts-pages-partials.html
+++ b/src/pages/learn/working-with-foundation-for-emails-layouts-pages-partials.html
@@ -6,7 +6,7 @@ name: Foundation for Emails Layouts, Pages, and Partials
   <h1 class="hero-main-header">{{name}}</h1>
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html" class="is-active">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/learn/zero-to-website-in-no-time-flat.html
+++ b/src/pages/learn/zero-to-website-in-no-time-flat.html
@@ -7,7 +7,7 @@ name: Go from Zero to Website in No Time Flat
 
   <ul class="marketing-subnav">
     <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
-    <li><a href="https://courses.zurb.com/">Courses</a></li>
+    <li><a href="https://zurb.com/university">Courses</a></li>
     <li><a href="https://zurb.com/university/lessons">Lessons</a></li>
     <li><a href="https://zurb.com/university/training">Custom Training</a></li>
     <!-- <li><a href="{{root}}learn/certification.html">Certification</a></li> -->

--- a/src/pages/showcase/about.html
+++ b/src/pages/showcase/about.html
@@ -197,7 +197,7 @@ name: About Foundation
         </div>
 
         <div class="medium-3 large-3 columns supporticons">
-          <a href="https://courses.zurb.com/">
+          <a href="https://zurb.com/university">
              <img src="{{root}}assets/img/learn/features/foundation-training.svg" />
              <h3>Foundation Training</h3>
            </a>

--- a/src/pages/templates.html
+++ b/src/pages/templates.html
@@ -22,7 +22,7 @@ name: HTML Templates
 
   <div class="row">
     <div class="medium-9 medium-centered columns">
-      <h4 class="page-intro"><strong>Get eight responsive templates to kick off your projects.</strong> Each of these responsive HTML templates were built with the same techniques and principles we teach in our <a class="sites" id="intro-foundation-course" href="https://courses.zurb.com/p/introduction-to-foundation-6">Introduction to Foundation 6 Course</a> to build your business upon. Sign up to get all the Foundation 6 templates delivered right to your inbox as well as monthly updates on where Foundation is headed, what's new, and loads of helpful resources!</h4>
+      <h4 class="page-intro"><strong>Get eight responsive templates to kick off your projects.</strong> Each of these responsive HTML templates were built with the same techniques and principles we teach in our <a class="sites" id="intro-foundation-course" href="https://zurb.com/university/foundation-intro">Introduction to Foundation 6 Course</a> to build your business upon. Sign up to get all the Foundation 6 templates delivered right to your inbox as well as monthly updates on where Foundation is headed, what's new, and loads of helpful resources!</h4>
 
       <div class="row">
         <div class="small-centered column medium-4">

--- a/src/pages/templates.html
+++ b/src/pages/templates.html
@@ -44,7 +44,7 @@ name: HTML Templates
     <div class="row small-up-2 medium-up-3 large-up-3 template-block">
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/news-magazine.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/f6-template-news-mag.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/news-magazine.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/f6-template-news-mag.svg"></a>
         <h5>News or Magazine</h5>
         <p>This template puts a focus on bold images, perfect for a magazine style site with eye catching content. Your stories are easy to find with large feature blocks.</p>
         <a href="{{root}}downloads/templates-sites/news-magazine.html" download class="button all-sites-download">Download</a>
@@ -53,7 +53,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/real-estate.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/f6-template-realestate.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/real-estate.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/f6-template-realestate.svg"></a>
         <h5>Real Estate or Travel</h5>
         <p>Big thumbnails with a space for captions and descriptions along with an informative header make this the perfect template for real estate or hotel booking.</p>
         <a href="{{root}}downloads/templates-sites/real-estate.html" download class="button all-sites-download">Download</a>
@@ -61,7 +61,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/ecommerce.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-04.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/ecommerce.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-04.svg"></a>
         <h5>Ecommerce Homepage</h5>
         <p>Building an online store? You'll appreciate this template's large Orbit powered hero slider and thumbnail patterns for items and buttons.</p>
         <a href="{{root}}downloads/templates-sites/ecommerce.html" download class="button all-sites-download">Download</a>
@@ -69,7 +69,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/agency.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-03.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/agency.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-03.svg"></a>
         <h5>Agency</h5>
         <p>Bring your work to the forefront with this sleek template that's perfect for agencies or freelancers.</p>
         <a href="{{root}}downloads/templates-sites/agency.html" download class="button all-sites-download">Download</a>
@@ -77,7 +77,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/blog.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-05.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/blog.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-05.svg"></a>
         <h5>Blog w/ Sidebar</h5>
         <p>Large images, an easy to navigate layout, and versatile sidebar will help you get your blog up and running.</p>
         <a href="{{root}}downloads/templates-sites/blog.html" download class="button all-sites-download">Download</a>
@@ -85,7 +85,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/blog-simple.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-06.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/blog-simple.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-06.svg"></a>
         <h5>Blog Single Column</h5>
         <p>This sleek, minimal approach can help your blog stand out by putting content front and center.</p>
         <a href="{{root}}downloads/templates-sites/blog-simple.html" download class="button all-sites-download">Download</a>
@@ -94,7 +94,7 @@ name: HTML Templates
 
           <!-- Template -->
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/portfolio.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-07.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/portfolio.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-07.svg"></a>
         <h5>Portfolio</h5>
         <p>Show off your work and highlight what you do with this grid style thumbnail layout.</p>
         <a href="{{root}}downloads/templates-sites/portfolio.html" download class="button all-sites-download">Download</a>
@@ -102,7 +102,7 @@ name: HTML Templates
       </div>
 
       <div class="column text-center">
-        <a class="img-link" href="{{root}}templates-previews-sites-f6/product-page.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-02.svg"></a>
+        <a class="img-link" href="{{root}}templates-previews-sites-f6-xy-grid/product-page.html"><img class="thumbnail" src="{{root}}assets/img/sites-templates/foundation6-templates-02.svg"></a>
         <h5>Product Page</h5>
         <p>Highlight your new product and educate potential customers with this classic template.</p>
         <a href="{{root}}downloads/templates-sites/product-page.html" download class="button all-sites-download">Download</a>

--- a/src/partials/footer-contact.html
+++ b/src/partials/footer-contact.html
@@ -4,7 +4,7 @@
     <div class="small-12 column text-center">
       <h5 class="homepage-section-subtitle lighter hide-me">Register today</h5>
       <span class="homepage-section-subtitle-divider lighter small-centered hide-me"></span>
-      <h1 class="homepage-section-title hide-me">Get all the answers in our <br><!-- August 8th --> <a class="hyperlink" href="https://courses.zurb.com/">Foundation Classes</a></h1>
+      <h1 class="homepage-section-title hide-me">Get all the answers in our <br><!-- August 8th --> <a class="hyperlink" href="https://zurb.com/university">Foundation Classes</a></h1>
     </div>
     <div class="small-11 medium-10 large-9 column text-center small-centered">
       <p class="homepage-section-desc hide-me">Learn Foundation from the creators in our on-demand online webinars which will keep you up to date with the latest trends and skills needed to win your projects.</p>
@@ -38,7 +38,7 @@
         <input type="hidden" name="_subject" value="ZURB | Foundation Training Inquiry">
         <input type="hidden" name="_to" value="contact@get.foundation">
       </form> -->
-      <a href="https://courses.zurb.com/" class="expanded large button home-form-submit-button">See Available Classes</a>
+      <a href="https://zurb.com/university" class="expanded large button home-form-submit-button">See Available Classes</a>
       <p class="text-center">Or if you prefer, contact the Foundation Team at <a class="text-link" href="mailto:contact@get.foundation">contact@get.foundation</a></p>
     </div>
   </div>

--- a/src/partials/footer-light.html
+++ b/src/partials/footer-light.html
@@ -17,7 +17,7 @@
             <ul>
                 <li><a href="{{root}}sites">Foundation for Sites</a></li>
 
-              <li><a href="https://courses.zurb.com/">Foundation Training</a></li>
+              <li><a href="https://zurb.com/university">Foundation Training</a></li>
               <li><a href="https://zurb.com/library">Design Resources</a></li>
             </ul>
           </div>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -16,7 +16,7 @@
         <a href="https://zurb.com/responsive">Showcase</a>
       </li>
       <li class="footer-nav-menu-item">
-        <a href="https://courses.zurb.com/">Training</a>
+        <a href="https://zurb.com/university">Training</a>
       </li>
       <li class="footer-nav-menu-item">
         <a href="{{root}}building-blocks/">Building Blocks</a>

--- a/src/partials/offcanvas-menu.html
+++ b/src/partials/offcanvas-menu.html
@@ -57,7 +57,7 @@
   <li><label class="first">Tutorials</label></li>
   <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
   <li><a href="https://zurb.com/university/lessons">Lessons <i class="fa fa-external-link"></i></a></li>
-  <li><a href="https://courses.zurb.com/">Courses <i class="fa fa-external-link"></i></a></li>
+  <li><a href="https://zurb.com/university">Courses <i class="fa fa-external-link"></i></a></li>
   <li><a href="https://zurb.com/university/training">Custom Training <i class="fa fa-external-link"></i></a></li>
   <li><a href="{{root}}learn/certification.html">Certification</a></li>
 </ul>

--- a/src/partials/topbar.html
+++ b/src/partials/topbar.html
@@ -38,7 +38,7 @@
       <ul class="submenu menu vertical" data-submenu>
         <li><a href="{{root}}learn/tutorials.html">Tutorials</a></li>
         <li><a href="https://zurb.com/university/lessons">Lessons <i class="fa fa-external-link"></i></a></li>
-        <li><a href="https://courses.zurb.com/">Courses <i class="fa fa-external-link"></i></a></li>
+        <li><a href="https://zurb.com/university">Courses <i class="fa fa-external-link"></i></a></li>
         <li><a href="https://zurb.com/university/training">Custom Training <i class="fa fa-external-link"></i></a></li>
         <li><a href="{{root}}learn/certification.html">Certification</a></li>
       </ul>

--- a/src/partials/training-class-benefits.html
+++ b/src/partials/training-class-benefits.html
@@ -39,7 +39,7 @@
   </div>
 
   <div class="row column medium-10 large-8">
-    <p class="page-intro mb0">To master everything new in 6.4, along with the rest of Foundation, check out the ZURB team's <a class="sites" href="https://courses.zurb.com/?utm_source=Tutorials&utm_medium=website&utm_campaign=XY%20Grid%20Tutorial&utm_content=XY%20Grid%20Tutorial%20top%20link">upcoming training opportunities.</a></p>
+    <p class="page-intro mb0">To master everything new in 6.4, along with the rest of Foundation, check out the ZURB team's <a class="sites" href="https://zurb.com/university?utm_source=Tutorials&utm_medium=website&utm_campaign=XY%20Grid%20Tutorial&utm_content=XY%20Grid%20Tutorial%20top%20link">upcoming training opportunities.</a></p>
   </div>
 
   <section class="testimonials">


### PR DESCRIPTION
Addresses some of the dead links mentioned in https://github.com/foundation/foundation-marketing/issues/21

There are three remaining dead links on this page for which I cannot figure out what the correct link should be: 
* https://zurb.com/responsive
* https://get.foundation/sites/download.html
* https://get.foundation/sites/download.html

This is my first PR here and I don't really know my way around this repo or Foundation in general. Happy to address feedback or for someone else who has a better understanding of this repo to take over this PR.