### PR TITLE
Correct the 404 from the homepage

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -17,7 +17,7 @@ name: The most advanced responsive front-end framework in the world.
     <div class="small-6 medium-offset-1 large-offset-2 end columns">
       <div id="watch">
         <section id="stargazers" class="sites">
-          <a id="stars" class="sites stars" href="foundation/foundation-sites">29.2k GitHub stars</a>
+          <a id="stars" class="sites stars" href="https://github.com/foundation/foundation-sites/stargazers">29.2k GitHub stars</a>
         </section>
         <section id="twitter">
           <a class="twitter" href="https://twitter.com/FoundationCSS">@FoundationCSS</a>


### PR DESCRIPTION
The current link goes to a 404.

This new link points to the correct location.